### PR TITLE
upgrade zip-dir version to fix issues on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "unzip": "0.1.11",
     "when": "3.7.2",
     "xml2js": "0.4.16",
-    "zip-dir": "1.0.1",
+    "zip-dir": "1.0.2",
     "jszip": "2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
zip-dir 1.0.1 introduced [a severe issue](https://github.com/jsantell/node-zip-dir/issues/6) where it could use 100% CPU usage. 1.0.2 fixes that.
